### PR TITLE
Fix random.choices weights

### DIFF
--- a/evol/population.py
+++ b/evol/population.py
@@ -79,18 +79,18 @@ class Population:
         return cls(chromosomes=chromosomes, eval_function=eval_func)
 
     @property
-    def individual_weights(self):
+    def _individual_weights(self):
         try:
-            min_fn = min(individual.fitness for individual in self)
-            max_fn = max(individual.fitness for individual in self)
+            min_fitness = min(individual.fitness for individual in self)
+            max_fitness = max(individual.fitness for individual in self)
         except TypeError:
             raise RuntimeError('Individual weights can not be computed if the individuals are not evaluated.')
-        if min_fn == max_fn:
+        if min_fitness == max_fitness:
             return [1] * len(self)
         elif self.maximize:
-            return [(individual.fitness - min_fn)/(max_fn-min_fn) for individual in self]
+            return [(individual.fitness - min_fitness)/(max_fitness-min_fitness) for individual in self]
         else:
-            return [1-(individual.fitness - min_fn) / (max_fn - min_fn) for individual in self]
+            return [1-(individual.fitness - min_fitness) / (max_fitness - min_fitness) for individual in self]
 
     def evolve(self, evolution: 'Evolution', n: int = 1) -> 'Population':
         """Evolve the population according to an Evolution.
@@ -190,7 +190,7 @@ class Population:
         if resulting_size > len(self.individuals):
             raise ValueError('everyone survives! must provide "fraction" and/or "n" < population size')
         if luck:
-            self.individuals = choices(self.individuals, k=resulting_size, weights=self.individual_weights)
+            self.individuals = choices(self.individuals, k=resulting_size, weights=self._individual_weights)
         else:
             sorted_individuals = sorted(self.individuals, key=lambda x: x.fitness, reverse=self.maximize)
             self.individuals = sorted_individuals[:resulting_size]

--- a/tests/test_population.py
+++ b/tests/test_population.py
@@ -195,14 +195,14 @@ class TestPopulationWeights(TestPopulation):
         for maximize in (False, True):
             pop = Population(chromosomes=self.chromosomes, eval_function=self.eval_func, maximize=maximize)
             with raises(RuntimeError):
-                _ = pop.individual_weights
+                _ = pop._individual_weights
             pop.evaluate()
-            assert max(pop.individual_weights) == 1
-            assert min(pop.individual_weights) == 0
+            assert max(pop._individual_weights) == 1
+            assert min(pop._individual_weights) == 0
             if maximize:
-                assert pop.individual_weights[0] == 0
+                assert pop._individual_weights[0] == 0
             else:
-                assert pop.individual_weights[0] == 1
+                assert pop._individual_weights[0] == 1
 
 
 class TestPopulationBest(TestPopulation):

--- a/tests/test_population.py
+++ b/tests/test_population.py
@@ -9,7 +9,7 @@ class TestPopulation:
 
     @property
     def chromosomes(self):
-        return list(range(200))
+        return list(range(-100, 100))
 
     @staticmethod
     def eval_func(x):
@@ -189,17 +189,33 @@ class TestPopulationMutate(TestPopulation):
             assert chromosome == 17
 
 
+class TestPopulationWeights(TestPopulation):
+
+    def test_weights(self):
+        for maximize in (False, True):
+            pop = Population(chromosomes=self.chromosomes, eval_function=self.eval_func, maximize=maximize)
+            with raises(RuntimeError):
+                _ = pop.individual_weights
+            pop.evaluate()
+            assert max(pop.individual_weights) == 1
+            assert min(pop.individual_weights) == 0
+            if maximize:
+                assert pop.individual_weights[0] == 0
+            else:
+                assert pop.individual_weights[0] == 1
+
+
 class TestPopulationBest(TestPopulation):
 
     def test_current_best(self):
-        for maximize, best in ((True, 199), (False, 0)):
+        for maximize, best in ((True, max(self.chromosomes)), (False, min(self.chromosomes))):
             pop = Population(chromosomes=self.chromosomes, eval_function=self.eval_func, maximize=maximize)
             assert pop.current_best is None
             pop.evaluate()
             assert pop.current_best.chromosome == best
 
     def test_current_worst(self):
-        for maximize, worst in ((False, 199), (True, 0)):
+        for maximize, worst in ((False, max(self.chromosomes)), (True, min(self.chromosomes))):
             pop = Population(chromosomes=self.chromosomes, eval_function=self.eval_func, maximize=maximize)
             assert pop.current_worst is None
             pop.evaluate()


### PR DESCRIPTION
There is a bug in the `survive` when `luck=True`; if the fitness of any individual is below zero it will fail. Also, the weights do not behave as intended, as they do not respond to `maximize` (which means that when `maximize=False` the worse candidates have a better chance) and when the difference in fitness in small compared to the average fitness, we have a rather random selection.

I've fixed this by properly normalising the weights.