### PR TITLE
Contestpopulation copy

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,6 @@
 from pytest import fixture
 
-from evol import Population
+from evol import Population, ContestPopulation
 
 
 @fixture(scope='module')
@@ -15,6 +15,19 @@ def simple_evaluation_function():
     return eval_func
 
 
+@fixture(scope='module')
+def simple_contest_evaluation_function():
+    def eval_func(x, y, z):
+        return [1, -1, 0] if x > y else [-1, 1, 0]
+    return eval_func
+
+
 @fixture(scope='function')
 def simple_population(simple_chromosomes, simple_evaluation_function):
     return Population(chromosomes=simple_chromosomes, eval_function=simple_evaluation_function)
+
+
+@fixture(scope='function')
+def simple_contestpopulation(simple_chromosomes, simple_contest_evaluation_function):
+    return ContestPopulation(chromosomes=simple_chromosomes, eval_function=simple_contest_evaluation_function,
+                             contests_per_round=35, individuals_per_contest=3)

--- a/conftest.py
+++ b/conftest.py
@@ -18,7 +18,7 @@ def simple_evaluation_function():
 @fixture(scope='module')
 def simple_contest_evaluation_function():
     def eval_func(x, y, z):
-        return [1, -1, 0] if x > y else [-1, 1, 0]
+        return [1, -1, 0] if x.chromosome > y.chromosome else [-1, 1, 0]
     return eval_func
 
 
@@ -31,3 +31,13 @@ def simple_population(simple_chromosomes, simple_evaluation_function):
 def simple_contestpopulation(simple_chromosomes, simple_contest_evaluation_function):
     return ContestPopulation(chromosomes=simple_chromosomes, eval_function=simple_contest_evaluation_function,
                              contests_per_round=35, individuals_per_contest=3)
+
+
+@fixture(scope='function', params=range(2))
+def any_population(request, simple_population, simple_contestpopulation):
+    if request.param == 0:
+        return simple_population
+    elif request.param == 1:
+        return simple_contestpopulation
+    else:
+        raise ValueError("invalid internal test config")

--- a/evol/population.py
+++ b/evol/population.py
@@ -371,6 +371,19 @@ class ContestPopulation(Population):
         self.contests_per_round = contests_per_round
         self.individuals_per_contest = individuals_per_contest
 
+    def __copy__(self):
+        result = self.__class__(chromosomes=self.chromosomes,
+                                eval_function=self.eval_function,
+                                maximize=self.maximize,
+                                contests_per_round=self.contests_per_round,
+                                individuals_per_contest=self.individuals_per_contest,
+                                serializer=self.serializer,
+                                intended_size=self.intended_size,
+                                logger=self.logger,
+                                generation=self.generation)
+        result.documented_best = None
+        return result
+
     def evaluate(self,
                  lazy: bool=False,
                  contests_per_round: Optional[int]=None,

--- a/tests/test_population.py
+++ b/tests/test_population.py
@@ -29,23 +29,17 @@ class TestPopulationSimple:
 
 class TestPopulationCopy:
 
-    def test_population_copy(self, simple_population):
-        copied_population = copy(simple_population)
-        for key in simple_population.__dict__.keys():
+    def test_population_copy(self, any_population):
+        copied_population = copy(any_population)
+        for key in any_population.__dict__.keys():
             if key not in ('id', 'individuals'):
-                assert copied_population.__dict__[key] == simple_population.__dict__[key]
-
-    def test_contestpopulation_copy(self, simple_contestpopulation):
-        copied_population = copy(simple_contestpopulation)
-        for key in simple_contestpopulation.__dict__.keys():
-            if key not in ('id', 'individuals'):
-                assert copied_population.__dict__[key] == simple_contestpopulation.__dict__[key]
+                assert copied_population.__dict__[key] == any_population.__dict__[key]
 
 
 class TestPopulationEvaluate:
 
-    def test_individuals_are_not_initially_evaluated(self, simple_population):
-        assert all([i.fitness is None for i in simple_population])
+    def test_individuals_are_not_initially_evaluated(self, any_population):
+        assert all([i.fitness is None for i in any_population])
 
     def test_evaluate_lambda(self, simple_chromosomes):
         pop = Population(simple_chromosomes, eval_function=lambda x: x)
@@ -61,8 +55,8 @@ class TestPopulationEvaluate:
         for individual in pop:
             assert evaluation_function(individual.chromosome) == individual.fitness
 
-    def test_evaluate_lazy(self, simple_population):
-        pop = simple_population
+    def test_evaluate_lazy(self, any_population):
+        pop = any_population
         pop.evaluate(lazy=True)  # should evaluate
 
         def raise_function(_):
@@ -101,14 +95,14 @@ class TestPopulationSurvive:
         assert len(pop2.survive(fraction=0.9, n=10)) == 10
         assert len(pop3.survive(fraction=0.5, n=190, luck=True)) == 100
 
-    def test_survive_throws_correct_errors(self, simple_population):
+    def test_survive_throws_correct_errors(self, any_population):
         """If the resulting population is zero or larger than initial we need to see errors."""
         with raises(RuntimeError):
-            simple_population.survive(n=0)
+            any_population.survive(n=0)
         with raises(ValueError):
-            simple_population.survive(n=250)
+            any_population.survive(n=250)
         with raises(ValueError):
-            simple_population.survive()
+            any_population.survive()
 
 
 class TestPopulationBreed:

--- a/tests/test_population.py
+++ b/tests/test_population.py
@@ -1,6 +1,6 @@
-from random import random, choices, seed
-
+from copy import copy
 from pytest import raises
+from random import random, choices, seed
 
 from evol import Population, ContestPopulation
 from evol.helpers.pickers import pick_random
@@ -25,6 +25,21 @@ class TestPopulationSimple:
         assert len(pop) == 200
         assert pop.intended_size == 200
         assert pop.individuals[0].chromosome == 1
+
+
+class TestPopulationCopy:
+
+    def test_population_copy(self, simple_population):
+        copied_population = copy(simple_population)
+        for key in simple_population.__dict__.keys():
+            if key not in ('id', 'individuals'):
+                assert copied_population.__dict__[key] == simple_population.__dict__[key]
+
+    def test_contestpopulation_copy(self, simple_contestpopulation):
+        copied_population = copy(simple_contestpopulation)
+        for key in simple_contestpopulation.__dict__.keys():
+            if key not in ('id', 'individuals'):
+                assert copied_population.__dict__[key] == simple_contestpopulation.__dict__[key]
 
 
 class TestPopulationEvaluate:


### PR DESCRIPTION
I've identified a bug which prevents the proper copying of
ContestPopulation objects. I haven't fixed it yet, but this commit
adds tests with at least trip over the bug.