### PR TITLE
Combiner signature

### DIFF
--- a/evol/helpers/combiners/generic.py
+++ b/evol/helpers/combiners/generic.py
@@ -1,6 +1,0 @@
-def select_min_fitness(*parents):
-    return min(parents, key=lambda parent: parent.fitness)
-
-
-def select_max_fitness(*parents):
-    return max(parents, key=lambda parent: parent.fitness)


### PR DESCRIPTION
The combiner signature has been changed to combine(*parents, **kwargs)
to combine(parents, **kwargs). This was done mainly to prevent users accidentally passing too many parents. E.g., if one has a combiner function like:
```
def combiner(mom, dad, x=1, y=0):
    return (mom+dad)/x + y
```
and one passes three parents and no kwargs the function is called as `combiner(*parents)`, which results in the third parent ending up as `x`. This only throws an error when `x` is also passed (and #76  is solved). Passing all parents as a sequence to a single argument solves this problem.