### PR TITLE
 Change way multiple offspring is handled

### DIFF
--- a/evol/helpers/combiners/__init__.py
+++ b/evol/helpers/combiners/__init__.py
@@ -1,1 +1,0 @@
-from ._utils import multiple_offspring

--- a/evol/helpers/combiners/_utils.py
+++ b/evol/helpers/combiners/_utils.py
@@ -86,9 +86,3 @@ def cycle_parity(cycles: List[Set[int]]) -> Dict[int, bool]:
     Indices in all odd cycles have parity False, while
     indices in even cycles have parity True."""
     return {index: bool(i % 2) for i, c in enumerate(cycles) for index in c}
-
-
-def multiple_offspring(f):
-    """Set the multiple offspring attribute of a combiner"""
-    f.multiple_offspring = True
-    return f

--- a/evol/helpers/combiners/permutation.py
+++ b/evol/helpers/combiners/permutation.py
@@ -2,7 +2,7 @@ from itertools import islice, tee
 from random import choice
 from typing import Any, Tuple
 
-from ._utils import select_node, construct_neighbors, multiple_offspring, identify_cycles, cycle_parity
+from ._utils import select_node, construct_neighbors, identify_cycles, cycle_parity
 from .._utils import select_partition
 
 
@@ -35,7 +35,6 @@ def edge_recombination(*parents: Tuple) -> Tuple:
     ))
 
 
-@multiple_offspring
 def cycle_crossover(parent_1: Tuple, parent_2: Tuple) -> Tuple[Tuple[Any, ...], ...]:
     """Combine two chromosomes using cycle crossover.
 
@@ -43,9 +42,10 @@ def cycle_crossover(parent_1: Tuple, parent_2: Tuple) -> Tuple[Tuple[Any, ...], 
 
     :param parent_1: First parent.
     :param parent_2: Second parent.
-    :return: Tuple of two child chromosomes.
+    :return: Child chromosome.
     """
     cycles = identify_cycles(parent_1, parent_2)
     parity = cycle_parity(cycles=cycles)
     it_a, it_b = tee((b, a) if parity[i] else (a, b) for i, (a, b) in enumerate(zip(parent_1, parent_2)))
-    return tuple(x[0] for x in it_a), tuple(y[1] for y in it_b)
+    yield tuple(x[0] for x in it_a)
+    yield tuple(y[1] for y in it_b)

--- a/evol/helpers/pickers.py
+++ b/evol/helpers/pickers.py
@@ -1,11 +1,11 @@
-from typing import Sequence
+from typing import Sequence, Tuple
 
 from random import choice
 
 from evol import Individual
 
 
-def pick_random(parents: Sequence[Individual], n_parents: int=2):
+def pick_random(parents: Sequence[Individual], n_parents: int=2) -> Tuple:
     """Randomly selects parents with replacement
 
     Accepted arguments:

--- a/evol/helpers/utils.py
+++ b/evol/helpers/utils.py
@@ -23,11 +23,11 @@ def offspring_generator(parents: List[Individual],
     """
     while True:
         # Obtain parent chromosomes
-        parents = parent_picker(parents, **kwargs)
-        if isinstance(parents, Individual):
-            chromosomes = (parents.chromosome,)
+        selected_parents = parent_picker(parents, **kwargs)
+        if isinstance(selected_parents, Individual):
+            chromosomes = (selected_parents.chromosome,)
         else:
-            chromosomes = tuple(individual.chromosome for individual in parents)
+            chromosomes = tuple(individual.chromosome for individual in selected_parents)
         # Create children
         if getattr(combiner, 'multiple_offspring', False):
             for child in combiner(*chromosomes, **kwargs):

--- a/tests/helpers/test_utils.py
+++ b/tests/helpers/test_utils.py
@@ -1,6 +1,53 @@
 from pytest import mark
 
-from evol.helpers.utils import select_arguments
+from evol import Individual, Population
+from evol.helpers.pickers import pick_random
+from evol.helpers.utils import select_arguments, offspring_generator
+
+
+class TestOffspringGenerator:
+
+    def test_simple_combiner(self, simple_population: Population):
+        def combiner(x, y):
+            return 1
+
+        result = offspring_generator(parents=simple_population.individuals,
+                                     parent_picker=pick_random, combiner=combiner)
+        assert isinstance(next(result), Individual)
+        assert next(result).chromosome == 1
+
+    @mark.parametrize('n_parents', [1, 2, 3, 4])
+    def test_args(self, n_parents: int, simple_population: Population):
+        def combiner(*parents, n_parents):
+            assert len(parents) == n_parents
+            return 1
+
+        result = offspring_generator(parents=simple_population.individuals, n_parents=n_parents,
+                                     parent_picker=pick_random, combiner=combiner)
+        assert isinstance(next(result), Individual)
+        assert next(result).chromosome == 1
+
+    def test_simple_picker(self, simple_population: Population):
+        def combiner(x):
+            return 1
+
+        def picker(parents):
+            return parents[0]
+
+        result = offspring_generator(parents=simple_population.individuals, parent_picker=picker, combiner=combiner)
+        assert isinstance(next(result), Individual)
+        assert next(result).chromosome == 1
+
+    def test_multiple_offspring(self, simple_population: Population):
+        def combiner(x, y):
+            yield 1
+            yield 2
+
+        result = offspring_generator(parents=simple_population.individuals,
+                                     parent_picker=pick_random, combiner=combiner)
+        for _ in range(10):
+            assert next(result).chromosome == 1
+            assert next(result).chromosome == 2
 
 
 class TestSelectArguments:


### PR DESCRIPTION
We no longer set a `multiple_offspring` attribute on the
combiner function, but instead a combiner may either return
a single chromosome or yield (one or more) chromosomes.