### PR TITLE
Change ContestPopulation evaluation signature

### DIFF
--- a/evol/population.py
+++ b/evol/population.py
@@ -355,12 +355,16 @@ class Contest:
     :param competitors: Iterable of Individuals in this Contest.
     """
 
-    def __init__(self, competitors: Iterable):
-        self.competitors = competitors
+    def __init__(self, competitors: Iterable[Individual]):
+        self.competitors = list(competitors)
 
     def assign_scores(self, scores: Sequence[float]) -> None:
         for competitor, score in zip(self.competitors, scores):
             competitor.fitness += score
+
+    @property
+    def competitor_chromosomes(self):
+        return [competitor.chromosome for competitor in self.competitors]
 
     @classmethod
     def generate(cls, individuals: Sequence[Individual],
@@ -504,10 +508,10 @@ class ContestPopulation(Population):
                                     contests_per_round=contests_per_round)
         if self.pool is None:
             for contest in contests:
-                contest.assign_scores(self.eval_function(*contest.competitors))
+                contest.assign_scores(self.eval_function(*contest.competitor_chromosomes))
         else:
             f = self.eval_function  # We cannot refer to self in the map
-            results = self.pool.map(lambda c: f(*c.competitors), contests)
+            results = self.pool.map(lambda c: f(*c.competitor_chromosomes), contests)
             for result, contest in zip(results, contests):
                 contest.assign_scores(result)
         return self

--- a/examples/rock_paper_scissors.py
+++ b/examples/rock_paper_scissors.py
@@ -34,7 +34,7 @@ class RockPaperScissorsPlayer:
 
 
 def evaluation_func(player_1, player_2):
-    choice_1, choice_2 = player_1.chromosome.play(), player_2.chromosome.play()
+    choice_1, choice_2 = player_1.play(), player_2.play()
     if choice_1 == choice_2:
         return [0, 0]
     elif choice_1 == 'rock':

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,7 @@ def simple_evaluation_function():
 @fixture(scope='module')
 def simple_contest_evaluation_function():
     def eval_func(x, y, z):
-        return [1, -1, 0] if x.chromosome > y.chromosome else [-1, 1, 0]
+        return [1, -1, 0] if x > y else [-1, 1, 0]
     return eval_func
 
 

--- a/tests/test_population.py
+++ b/tests/test_population.py
@@ -319,13 +319,13 @@ class TestContestPopulationBest:
         pop.evaluate()
         assert pop.documented_best is None
         pop = ContestPopulation([0, 1, 2],
-                                lambda x, y: [x.chromosome, y.chromosome],
+                                lambda x, y: [x, y],
                                 contests_per_round=100, individuals_per_contest=2)
         pop.evaluate()
         assert pop.documented_best is None
         # with concurrency
         pop = ContestPopulation([0, 1, 2],
-                                lambda x, y: [x.chromosome, y.chromosome],
+                                lambda x, y: [x, y],
                                 contests_per_round=100, individuals_per_contest=2,
                                 concurrent_workers=3)
         pop.evaluate()


### PR DESCRIPTION
Changed the expected signature of the ContestPopulation evaluations
function from `eval(individual, ...) -> List[scores]`
to `eval(chromosome, ...) -> List[scores]` to match the expected
signature of the Population evaluation function with
a signature `eval(chromosome) -> score`.

This has the effect that all users of the ContestPopulation must
modify their evaluation function to expect a chromosome instead of
an individual.