### PR TITLE
Fix bug which prevented RepeatSteps from working

### DIFF
--- a/evol/__init__.py
+++ b/evol/__init__.py
@@ -119,4 +119,4 @@ from .population import Population, ContestPopulation
 from .evolution import Evolution
 from .logger import BaseLogger
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"

--- a/evol/population.py
+++ b/evol/population.py
@@ -176,7 +176,7 @@ class Population:
         result = copy(self)
         for _ in range(n):
             for step in evolution:
-                step.apply(result)
+                result = step.apply(result)
         return result
 
     def evaluate(self, lazy: bool = False) -> 'Population':

--- a/tests/test_evolution.py
+++ b/tests/test_evolution.py
@@ -1,4 +1,4 @@
-from evol import Evolution
+from evol import Evolution, Population
 
 
 class TestEvolution:
@@ -9,3 +9,12 @@ class TestEvolution:
         evo_step = evo._add_step('step')
         assert len(evo.chain) == 0  # original unchanged
         assert evo_step.chain == ['step']  # copy with extra step
+
+
+class TestPopulationEvolve:
+
+    def test_repeat_step(self):
+        pop = Population([0 for i in range(100)], lambda x: x)
+        evo = Evolution().repeat(Evolution().survive(fraction=0.9), n=10)
+        # Check whether an Evolution inside another Evolution is actually applied
+        assert len(pop.evolve(evo, n=2)) < 50


### PR DESCRIPTION
This one is pretty bad... since the `evolve` method is the only one _not_ to work in place, and the `evolve` method assumed that all sub-steps work in place, `RepeatSteps` were not working.

Fixed and added a test