### PR TITLE
Increment the generation after every survive step.

### DIFF
--- a/evol/population.py
+++ b/evol/population.py
@@ -31,7 +31,8 @@ class Population:
         Defaults to True.
     :param logger: Logger object for the Population. If None, a new BaseLogger
         is created. Defaults to None.
-    :param generation: Generation of the Population. Defaults to 0.
+    :param generation: Generation of the Population. This is incremented after
+        each survive call. Defaults to 0.
     :param intended_size: Intended size of the Population. The population will
         be replenished to this size by .breed(). Defaults to the number of
         chromosomes provided.
@@ -241,6 +242,8 @@ class Population:
         Remove part of the population. If both fraction and n are specified,
         the minimum resulting population size is taken.
 
+        This increments the generation of the Population.
+
         :param fraction: Fraction of the original population that survives.
             Defaults to None.
         :param n: Number of individuals of the population that survive.
@@ -262,6 +265,7 @@ class Population:
             raise RuntimeError('no one survived!')
         if resulting_size > len(self.individuals):
             raise ValueError('everyone survives! must provide "fraction" and/or "n" < population size')
+        self.generation += 1
         if luck:
             self.individuals = choices(self.individuals, k=resulting_size, weights=self._individual_weights)
         else:
@@ -557,6 +561,8 @@ class ContestPopulation(Population):
         Remove part of the population. If both fraction and n are specified,
         the minimum resulting population size is taken. Resets the fitness
         of all individuals.
+
+        This increments the generation of the ContestPopulation.
 
         :param fraction: Fraction of the original population that survives.
             Defaults to None.

--- a/evol/population.py
+++ b/evol/population.py
@@ -32,7 +32,7 @@ class Population:
     :param logger: Logger object for the Population. If None, a new BaseLogger
         is created. Defaults to None.
     :param generation: Generation of the Population. This is incremented after
-        each survive call. Defaults to 0.
+        each breed call. Defaults to 0.
     :param intended_size: Intended size of the Population. The population will
         be replenished to this size by .breed(). Defaults to the number of
         chromosomes provided.
@@ -242,8 +242,6 @@ class Population:
         Remove part of the population. If both fraction and n are specified,
         the minimum resulting population size is taken.
 
-        This increments the generation of the Population.
-
         :param fraction: Fraction of the original population that survives.
             Defaults to None.
         :param n: Number of individuals of the population that survive.
@@ -265,7 +263,6 @@ class Population:
             raise RuntimeError('no one survived!')
         if resulting_size > len(self.individuals):
             raise ValueError('everyone survives! must provide "fraction" and/or "n" < population size')
-        self.generation += 1
         if luck:
             self.individuals = choices(self.individuals, k=resulting_size, weights=self._individual_weights)
         else:
@@ -279,6 +276,8 @@ class Population:
               population_size: Optional[int] = None,
               **kwargs) -> 'Population':
         """Create new individuals by combining existing individuals.
+
+        This increments the generation of the Population.
 
         :param parent_picker: Function that selects parents from a collection of individuals.
         :param combiner: Function that combines chromosomes into a new
@@ -298,6 +297,7 @@ class Population:
                                         combiner=select_arguments(combiner),
                                         **kwargs)
         self.individuals += list(islice(offspring, self.intended_size - len(self.individuals)))
+        self.generation += 1
         return self
 
     def mutate(self,
@@ -424,7 +424,8 @@ class ContestPopulation(Population):
         per round is a multiple of individuals_per_contest. Defaults to 10.
     :param logger: Logger object for the Population. If None, a new BaseLogger
         is created. Defaults to None.
-    :param generation: Generation of the Population. Defaults to 0.
+    :param generation: Generation of the Population. This is incremented after
+        echo survive call. Defaults to 0.
     :param intended_size: Intended size of the Population. The population will
         be replenished to this size by .breed(). Defaults to the number of
         chromosomes provided.
@@ -561,8 +562,6 @@ class ContestPopulation(Population):
         Remove part of the population. If both fraction and n are specified,
         the minimum resulting population size is taken. Resets the fitness
         of all individuals.
-
-        This increments the generation of the ContestPopulation.
 
         :param fraction: Fraction of the original population that survives.
             Defaults to None.

--- a/tests/test_population.py
+++ b/tests/test_population.py
@@ -131,6 +131,9 @@ class TestPopulationSurvive:
         assert len(pop2.survive(fraction=0.9, n=10)) == 10
         assert len(pop3.survive(fraction=0.5, n=190, luck=True)) == 100
 
+    def test_survive_increases_generation(self, any_population):
+        assert any_population.survive(fraction=0.5).generation == 1
+
     def test_survive_throws_correct_errors(self, any_population):
         """If the resulting population is zero or larger than initial we need to see errors."""
         with raises(RuntimeError):

--- a/tests/test_population.py
+++ b/tests/test_population.py
@@ -238,7 +238,7 @@ class TestPopulationWeights:
             pop = Population(chromosomes=simple_chromosomes,
                              eval_function=simple_evaluation_function, maximize=maximize)
             with raises(RuntimeError):
-                pop._individual_weights
+                _ = pop._individual_weights
             pop.evaluate()
             assert max(pop._individual_weights) == 1
             assert min(pop._individual_weights) == 0

--- a/tests/test_population.py
+++ b/tests/test_population.py
@@ -131,8 +131,8 @@ class TestPopulationSurvive:
         assert len(pop2.survive(fraction=0.9, n=10)) == 10
         assert len(pop3.survive(fraction=0.5, n=190, luck=True)) == 100
 
-    def test_survive_increases_generation(self, any_population):
-        assert any_population.survive(fraction=0.5).generation == 1
+    def test_breed_increases_generation(self, any_population):
+        assert any_population.breed(parent_picker=pick_random, combiner=lambda mom, dad: mom).generation == 1
 
     def test_survive_throws_correct_errors(self, any_population):
         """If the resulting population is zero or larger than initial we need to see errors."""
@@ -156,6 +156,8 @@ class TestPopulationBreed:
                                  combiner=lambda mom, dad: (mom + dad) / 2, population_size=400)
         assert len(pop2) == 400
         assert pop2.intended_size == 400
+        assert pop1.generation == 1
+        assert pop2.generation == 1
 
     def test_breed_works_with_kwargs(self, simple_chromosomes, simple_evaluation_function):
         pop1 = Population(chromosomes=simple_chromosomes, eval_function=simple_evaluation_function)

--- a/tests/test_population.py
+++ b/tests/test_population.py
@@ -238,7 +238,7 @@ class TestPopulationWeights:
             pop = Population(chromosomes=simple_chromosomes,
                              eval_function=simple_evaluation_function, maximize=maximize)
             with raises(RuntimeError):
-                _ = pop._individual_weights
+                assert min(pop._individual_weights) >= 0
             pop.evaluate()
             assert max(pop._individual_weights) == 1
             assert min(pop._individual_weights) == 0


### PR DESCRIPTION
Currently our `Population` has a `generation` attribute which defaults to zero and is never touched. I suggest we increment it after each `survive` step. Of course we can also decide to pick another operation after which we increment it, but I think `survive` is the most universal. Alternatively we could drop the attribute altogether, but in debugging the `RepeatStep` case (see other PR) it proved quite useful.