### PR TITLE
Do not copy population on callback and add test

### DIFF
--- a/evol/population.py
+++ b/evol/population.py
@@ -279,7 +279,7 @@ class BasePopulation(metaclass=ABCMeta):
         :return:
         """
         self.evaluate(lazy=True)
-        callback_function(copy(self), **kwargs)
+        callback_function(self, **kwargs)
         return self
 
     def _update_documented_best(self):

--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -41,3 +41,10 @@ class TestPopulationSimple:
         pop.evolve(evolution=evo, n=10)
         assert counter.count == len(simple_chromosomes) * 5
         assert counter.sum == sum(simple_chromosomes) * 5
+
+    def test_is_evaluated(self, simple_population):
+        def assert_is_evaluated(pop: Population):
+            assert pop.current_best is not None
+
+        simple_population.evaluate(lazy=True)
+        simple_population.callback(assert_is_evaluated)


### PR DESCRIPTION
This is supposed to solve #132 .

In addition to this we can also ensure that fitness is copied on population copy. I'm inclined to do that as well, in a separate PR.