### PR TITLE
Copy individuals not chromosomes

### DIFF
--- a/evol/population.py
+++ b/evol/population.py
@@ -338,7 +338,7 @@ class Population(BasePopulation):
                          serializer=serializer)
 
     def __copy__(self):
-        result = self.__class__(chromosomes=self.chromosomes,
+        result = self.__class__(chromosomes=[],
                                 eval_function=self.eval_function,
                                 maximize=self.maximize,
                                 serializer=self.serializer,
@@ -346,6 +346,7 @@ class Population(BasePopulation):
                                 logger=self.logger,
                                 generation=self.generation,
                                 concurrent_workers=1)  # Prevent new pool from being made
+        result.individuals = [copy(individual) for individual in self.individuals]
         result.concurrent_workers = self.concurrent_workers
         result.pool = self.pool
         result.documented_best = self.documented_best
@@ -496,7 +497,7 @@ class ContestPopulation(BasePopulation):
         self.individuals_per_contest = individuals_per_contest
 
     def __copy__(self):
-        result = self.__class__(chromosomes=self.chromosomes,
+        result = self.__class__(chromosomes=[],
                                 eval_function=self.eval_function,
                                 maximize=self.maximize,
                                 contests_per_round=self.contests_per_round,
@@ -506,9 +507,11 @@ class ContestPopulation(BasePopulation):
                                 logger=self.logger,
                                 generation=self.generation,
                                 concurrent_workers=1)
+        result.individuals = [copy(individual) for individual in self.individuals]
         result.pool = self.pool
         result.concurrent_workers = self.concurrent_workers
         result.documented_best = None
+        result.reset_fitness()
         return result
 
     def evaluate(self,

--- a/evol/population.py
+++ b/evol/population.py
@@ -76,6 +76,10 @@ class BasePopulation(metaclass=ABCMeta):
         for individual in self.individuals:
             yield individual.chromosome
 
+    @property
+    def is_evaluated(self) -> bool:
+        return all(individual.fitness is not None for individual in self)
+
     @classmethod
     def generate(cls,
                  init_function: Callable[[], Any],

--- a/evol/population.py
+++ b/evol/population.py
@@ -511,7 +511,6 @@ class ContestPopulation(BasePopulation):
         result.pool = self.pool
         result.concurrent_workers = self.concurrent_workers
         result.documented_best = None
-        result.reset_fitness()
         return result
 
     def evaluate(self,

--- a/tests/test_individual.py
+++ b/tests/test_individual.py
@@ -1,3 +1,5 @@
+from copy import copy
+
 from evol import Individual
 
 
@@ -8,6 +10,16 @@ class TestIndividual:
         ind = Individual(chromosome=chromosome)
         assert chromosome == ind.chromosome
         assert ind.fitness is None
+
+    def test_copy(self):
+        individual = Individual(chromosome=(1, 2))
+        individual.evaluate(sum)
+        copied_individual = copy(individual)
+        assert individual.chromosome == copied_individual.chromosome
+        assert individual.fitness == copied_individual.fitness
+        assert individual.id == copied_individual.id
+        copied_individual.mutate(lambda x: (2, 3))
+        assert individual.chromosome == (1, 2)
 
     def test_evaluate(self):
         ind = Individual(chromosome=(1, 2))

--- a/tests/test_population.py
+++ b/tests/test_population.py
@@ -43,6 +43,18 @@ class TestPopulationCopy:
             if key not in ('id', 'individuals'):
                 assert copied_population.__dict__[key] == any_population.__dict__[key]
 
+    def test_population_is_evaluated(self, simple_population):
+        evaluated_population = simple_population.evaluate()
+        copied_population = copy(evaluated_population)
+        assert evaluated_population.is_evaluated
+        assert copied_population.is_evaluated
+
+    def test_contestpopulation_is_evaluated(self, simple_contestpopulation):
+        evaluated_population = simple_contestpopulation.evaluate()
+        copied_population = copy(evaluated_population)
+        assert evaluated_population.is_evaluated
+        assert not copied_population.is_evaluated
+
 
 class TestPopulationEvaluate:
 

--- a/tests/test_population.py
+++ b/tests/test_population.py
@@ -30,6 +30,10 @@ class TestPopulationSimple:
         assert pop.intended_size == 200
         assert pop.individuals[0].chromosome == 1
 
+    def test_is_evaluated(self, any_population):
+        assert not any_population.is_evaluated
+        assert any_population.evaluate().is_evaluated
+
 
 class TestPopulationCopy:
 

--- a/tests/test_population.py
+++ b/tests/test_population.py
@@ -43,17 +43,11 @@ class TestPopulationCopy:
             if key not in ('id', 'individuals'):
                 assert copied_population.__dict__[key] == any_population.__dict__[key]
 
-    def test_population_is_evaluated(self, simple_population):
-        evaluated_population = simple_population.evaluate()
+    def test_population_is_evaluated(self, any_population):
+        evaluated_population = any_population.evaluate()
         copied_population = copy(evaluated_population)
         assert evaluated_population.is_evaluated
         assert copied_population.is_evaluated
-
-    def test_contestpopulation_is_evaluated(self, simple_contestpopulation):
-        evaluated_population = simple_contestpopulation.evaluate()
-        copied_population = copy(evaluated_population)
-        assert evaluated_population.is_evaluated
-        assert not copied_population.is_evaluated
 
 
 class TestPopulationEvaluate:


### PR DESCRIPTION
When copying a population, copy individuals instead of creating new individuals. This ensures that the fitness is retained.