### PR TITLE
Remove generic combiners

### DIFF
--- a/evol/helpers/combiners/generic.py
+++ b/evol/helpers/combiners/generic.py
@@ -1,6 +1,0 @@
-def select_min_fitness(*parents):
-    return min(parents, key=lambda parent: parent.fitness)
-
-
-def select_max_fitness(*parents):
-    return max(parents, key=lambda parent: parent.fitness)


### PR DESCRIPTION
The generic combiners have a signature that does not match our expected
signature for combiners. While we expect a combiner to accept a number
of chromosomes, these combiners except individuals.

As I think that a combiner should solely combine two chromosomes, and
all logic related to the fitness of individuals selected for combining
should be handled by the picker, I've removed them.