### PR TITLE
Flake8 Fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 .PHONY: docs
 
 flake:
-	python setup.py flake8
+	python -m flake8 evol
+	python -m flake8 tests
 
 install:
 	pip install -e .
@@ -13,7 +14,7 @@ develop:
 test:
 	python setup.py test
 
-check: test flake
+check: flake test
 
 docs:
 	sphinx-apidoc -f -o doc/api evol

--- a/evol/helpers/combiners/utils.py
+++ b/evol/helpers/combiners/utils.py
@@ -7,8 +7,8 @@ from typing import Iterable, Generator, Any, Set, List, Dict, Tuple
 
 def construct_neighbors(*chromosome: Tuple[Any]) -> defaultdict:
     result = defaultdict(set)
-    for l in chromosome:
-        for x, y in _neighbors_in(l):
+    for item in chromosome:
+        for x, y in _neighbors_in(item):
             result[x].add(y)
             result[y].add(x)
     return result

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -43,12 +43,12 @@ class TestLoggerSimple:
         logger.log(pop, foo="bar")
         with open(log_file, "r") as f:
             assert len(f.readlines()) == len(simple_chromosomes)
-            assert all(["bar" in l for l in f.readlines()])
+            assert all(["bar" in item for item in f.readlines()])
         # we should see that a file was created with an appropriate number of rows
         logger.log(pop, foo="meh")
         with open(log_file, "r") as f:
             assert len(f.readlines()) == (2 * len(simple_chromosomes))
-            assert all(['meh' in l for l in f.readlines()[-10:]])
+            assert all(['meh' in item for item in f.readlines()[-10:]])
 
     def test_baselogger_works_via_evolution_callback(self, tmpdir, capsys):
         log_file = tmpdir.join('log.txt')


### PR DESCRIPTION
I've made the repo flake8 compatible again and I've changed the Makefile. Flake8 raised this warning without the change;

```
WARNING: flake8 setuptools integration is deprecated and scheduled for removal in 4.x.  For more information, see https://gitlab.com/pycqa/flake8/issues/544
```