### PR TITLE
Elitist mutation

### DIFF
--- a/evol/evolution.py
+++ b/evol/evolution.py
@@ -147,6 +147,7 @@ class Evolution:
     def mutate(self,
                mutate_function: Callable[..., Any],
                probability: float = 1.0,
+               elitist: bool = False,
                name: Optional[str] = None,
                **kwargs) -> 'Evolution':
         """Add a mutate step to the Evolution.
@@ -158,12 +159,17 @@ class Evolution:
         :param probability: Probability that the individual mutates.
             The function is only applied in the given fraction of cases.
             Defaults to 1.0.
+        :param elitist: If True, do not mutate the current best individual(s).
+            Note that this only applies to evaluated individuals. Any unevaluated
+            individual will be treated as normal.
+            Defaults to False.
         :param name: Name of the mutate step.
         :param kwargs: Kwargs to pass to the parent_picker and combiner.
             Arguments are only passed to the functions if they accept them.
         :return: self
         """
-        return self._add_step(MutateStep(name=name, probability=probability, mutate_function=mutate_function, **kwargs))
+        return self._add_step(MutateStep(name=name, probability=probability, elitist=elitist,
+                                         mutate_function=mutate_function, **kwargs))
 
     def repeat(self, evolution: 'Evolution', n: int = 1, name: Optional[str] = None,
                grouping_function: Optional[Callable] = None, **kwargs) -> 'Evolution':

--- a/evol/population.py
+++ b/evol/population.py
@@ -191,7 +191,8 @@ class BasePopulation(metaclass=ABCMeta):
 
     def mutate(self,
                mutate_function: Callable[..., Any],
-               probability: float = 1.0, **kwargs) -> 'BasePopulation':
+               probability: float = 1.0,
+               elitist: bool = False, **kwargs) -> 'BasePopulation':
         """Mutate the chromosome of each individual.
 
         :param mutate_function: Function that accepts a chromosome and returns
@@ -199,11 +200,17 @@ class BasePopulation(metaclass=ABCMeta):
         :param probability: Probability that the individual mutates.
             The function is only applied in the given fraction of cases.
             Defaults to 1.0.
+        :param elitist: If True, do not mutate the current best individual(s).
+            Note that this only applies to evaluated individuals. Any unevaluated
+            individual will be treated as normal.
+            Defaults to False.
         :param kwargs: Arguments to pass to the mutation function.
         :return: self
         """
+        elite_fitness = self.current_best if elitist else None
         for individual in self.individuals:
-            individual.mutate(mutate_function, probability=probability, **kwargs)
+            if elite_fitness is None or individual.fitness != elite_fitness:
+                individual.mutate(mutate_function, probability=probability, **kwargs)
         return self
 
     def map(self, func: Callable[..., Individual], **kwargs) -> 'BasePopulation':

--- a/examples/travelling_salesman.py
+++ b/examples/travelling_salesman.py
@@ -48,7 +48,7 @@ def run_travelling_salesman(population_size: int = 100,
     island_evo = (Evolution()
                   .survive(fraction=0.5)
                   .breed(parent_picker=pick_random, combiner=cycle_crossover)
-                  .mutate(swap_elements))
+                  .mutate(swap_elements, elitist=True))
 
     evo = (Evolution()
            .evaluate(lazy=True)

--- a/tests/test_population.py
+++ b/tests/test_population.py
@@ -241,6 +241,12 @@ class TestPopulationMutate:
         for chromosome in pop.chromosomes:
             assert chromosome == 17
 
+    def test_mutate_elitist(self):
+        pop = Population([1, 1, 3], eval_function=lambda x: x).evaluate().mutate(lambda x: x + 1, elitist=True)
+        for chromosome in pop.chromosomes:
+            assert chromosome > 1
+        assert len(pop) == 3
+
 
 class TestPopulationWeights:
 


### PR DESCRIPTION
This adds a flag to let `mutate` behave elitist, i.e. never mutate any individual with a fitness equal to that of the best fitness.